### PR TITLE
12 Fix button 'exescorm:editonlineandreturntocourse'

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -649,7 +649,7 @@ class mod_exescorm_mod_form extends moodleform_mod {
                     $returnto = new moodle_url("/mod/exescorm/view.php", ['id' => $data->coursemodule, 'forceview' => 1]);
                 } else {
                     // Return to course.
-                    $returnto = course_get_url($data->course, $data->coursesection ?? null, array('sr' => $data->sr));
+                    $returnto = course_get_url($data->course, null, array());
                 }
                 // Set this becouse modedit.php expects it.
                 $data->submitbutton = true;


### PR DESCRIPTION
**Now the JWT is correctly generated when we press "Edit on eXeLearning and return to course" button.**
---
> ![image](https://github.com/user-attachments/assets/8271b8f1-c561-4c07-8847-2d9560c0c7da)
---