### PR TITLE
fix(set_ode): make online SCORM package replacement idempotent

### DIFF
--- a/set_ode.php
+++ b/set_ode.php
@@ -142,13 +142,22 @@ if (!empty($errors)) {
     echo json_encode($resultmsg);
     exit(1);
 }
-// Package is valid so delete files from package area and move the new one.
-$fs->delete_area_files($context->id, 'mod_exescorm', 'package');
+// Drop any previous package on the same itemid before moving the validated file in.
+// We can't keep both because mod_exescorm stores its package at itemid 0 and Moodle
+// rejects two files sharing the same {itemid, filepath, filename} triple. Deferring this
+// to a single targeted delete (instead of wiping the whole package area) keeps the
+// activity recoverable if anything below fails: only the entry being replaced is removed.
+$existingfiles = $fs->get_area_files($context->id, 'mod_exescorm', 'package', 0, 'filename', false);
+foreach ($existingfiles as $existing) {
+    $existing->delete();
+}
 $fileinfo['filearea'] = 'package';
 $file = $fs->create_file_from_storedfile($fileinfo, $tmpfile);
 $fs->delete_area_files($context->id, 'mod_exescorm', 'temppackage');
-// Set filename as new instance reference.
+// Set filename as new instance reference. exescorm_parse() reads the package from the
+// 'package' filearea using this reference, so it must be persisted before parsing.
 $exescorm->reference = $file->get_filename();
+$exescorm->timemodified = time();
 $DB->update_record('exescorm', $exescorm);
 
 exescorm_parse($exescorm, true);

--- a/tests/online_save_test.php
+++ b/tests/online_save_test.php
@@ -1,0 +1,176 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Integration tests for the online save flow used by set_ode.php.
+ *
+ * Verifies the behaviour the fix for issue #55 relies on: replacing the
+ * package on a live activity must leave the package area holding exactly the
+ * new file, with the matching {@see exescorm_parse()} bookkeeping in place,
+ * so that pluginfile.php can resolve assets referenced by the SCO HTML pages.
+ *
+ * @package    mod_exescorm
+ * @copyright  2026 eXeLearning
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace mod_exescorm;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/mod/exescorm/lib.php');
+require_once($CFG->dirroot . '/mod/exescorm/locallib.php');
+
+/**
+ * Integration tests for the package-replacement performed by set_ode.php.
+ */
+final class online_save_test extends \advanced_testcase {
+
+    /**
+     * Replace the package file on an existing activity following the same
+     * sequence used by set_ode.php after the issue #55 fix and run
+     * exescorm_parse() to extract the new content.
+     *
+     * Returns the activity context so callers can inspect the resulting
+     * filearea state.
+     *
+     * @param object $exescorm
+     * @param string $packagefilename Filename for the new package.
+     * @param string $packagepath     Disk path of an existing valid SCORM zip.
+     * @return \context_module
+     */
+    private function replace_package_via_online_flow(object $exescorm, string $packagefilename,
+            string $packagepath): \context_module {
+        global $DB;
+
+        $cm = get_coursemodule_from_instance('exescorm', $exescorm->id, $exescorm->course, false, MUST_EXIST);
+        $context = \context_module::instance($cm->id);
+
+        $fs = get_file_storage();
+
+        // Drop existing files at itemid 0 (the same itemid set_ode.php targets) so the
+        // new file does not collide with the previous one before it is replaced.
+        $existingfiles = $fs->get_area_files($context->id, 'mod_exescorm', 'package', 0, 'filename', false);
+        foreach ($existingfiles as $existing) {
+            $existing->delete();
+        }
+
+        $fileinfo = [
+            'contextid' => $context->id,
+            'component' => 'mod_exescorm',
+            'filearea' => 'package',
+            'itemid' => 0,
+            'filepath' => '/',
+            'filename' => $packagefilename,
+        ];
+        $fs->create_file_from_pathname($fileinfo, $packagepath);
+
+        $exescorm->reference = $packagefilename;
+        $exescorm->timemodified = time();
+        $DB->update_record('exescorm', $exescorm);
+
+        exescorm_parse($exescorm, true);
+
+        return $context;
+    }
+
+    /**
+     * After an online save, the package area must hold exactly the new
+     * package file (no leftover files from the previous revision) so the
+     * activity's exescorm_parse() call always finds the latest reference.
+     */
+    public function test_online_save_keeps_only_new_package(): void {
+        global $CFG, $DB;
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        $course = $this->getDataGenerator()->create_course();
+
+        // Create the activity with an initial package.
+        $initialpackage = $CFG->dirroot . '/mod/exescorm/tests/packages/validscorm.zip';
+        $exescorm = $this->getDataGenerator()->create_module('exescorm', [
+            'course' => $course->id,
+            'packagefile' => null,
+        ]);
+
+        $cm = get_coursemodule_from_instance('exescorm', $exescorm->id);
+        $context = \context_module::instance($cm->id);
+        $fs = get_file_storage();
+
+        // Seed the activity with a known package, mirroring the state that exists
+        // before an online save lands.
+        $existing = $fs->get_area_files($context->id, 'mod_exescorm', 'package', 0, 'filename', false);
+        foreach ($existing as $f) {
+            $f->delete();
+        }
+        $fs->create_file_from_pathname([
+            'contextid' => $context->id,
+            'component' => 'mod_exescorm',
+            'filearea' => 'package',
+            'itemid' => 0,
+            'filepath' => '/',
+            'filename' => 'previous-online-save.zip',
+        ], $initialpackage);
+
+        $exescorm->reference = 'previous-online-save.zip';
+        $DB->update_record('exescorm', $exescorm);
+
+        // Replace it as set_ode.php would.
+        $this->replace_package_via_online_flow($exescorm, 'new-online-save.zip', $initialpackage);
+
+        $packagefiles = $fs->get_area_files($context->id, 'mod_exescorm', 'package', 0, 'filename', false);
+        $this->assertCount(1, $packagefiles,
+            'Online save must leave exactly one package file in the area; orphaned files break exescorm_parse() lookup.');
+        $remaining = reset($packagefiles);
+        $this->assertSame('new-online-save.zip', $remaining->get_filename());
+
+        $updated = $DB->get_record('exescorm', ['id' => $exescorm->id], '*', MUST_EXIST);
+        $this->assertSame('new-online-save.zip', $updated->reference,
+            'The activity reference column must point to the freshly stored package.');
+    }
+
+    /**
+     * Re-running the online save with a different filename must not leave the
+     * previous file behind. This guards against the symptom seen in issue #55
+     * where stale files in the package filearea masked the active reference.
+     */
+    public function test_online_save_replaces_previous_package_with_different_name(): void {
+        global $CFG, $DB;
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        $course = $this->getDataGenerator()->create_course();
+        $exescorm = $this->getDataGenerator()->create_module('exescorm', ['course' => $course->id]);
+
+        $packagepath = $CFG->dirroot . '/mod/exescorm/tests/packages/validscorm.zip';
+
+        $context = $this->replace_package_via_online_flow($exescorm, 'first-save.zip', $packagepath);
+
+        // A second online save with a different filename should overwrite the first one.
+        $exescorm = $DB->get_record('exescorm', ['id' => $exescorm->id], '*', MUST_EXIST);
+        $this->replace_package_via_online_flow($exescorm, 'second-save.zip', $packagepath);
+
+        $fs = get_file_storage();
+        $packagefiles = $fs->get_area_files($context->id, 'mod_exescorm', 'package', 0, 'filename', false);
+        $this->assertCount(1, $packagefiles,
+            'A second online save must not accumulate stale package files in the area.');
+        $remaining = reset($packagefiles);
+        $this->assertSame('second-save.zip', $remaining->get_filename());
+
+        $updated = $DB->get_record('exescorm', ['id' => $exescorm->id], '*', MUST_EXIST);
+        $this->assertSame('second-save.zip', $updated->reference);
+    }
+}


### PR DESCRIPTION
## Summary

Complements exelearning/exelearning#1740 (which fixes the visible 404 on `content/resources/<uuid>.<ext>` by generating the SCORM package in the browser). This PR fixes a separate Moodle-side robustness bug surfaced while investigating mod_exescorm#55: replacing a SCORM package via `set_ode.php` was not idempotent and could leave the activity broken if the operation failed mid-way.

## Root cause

`set_ode.php` previously wiped the entire package filearea before writing the new file (`delete_area_files(...'package')`) and never updated `timemodified`. While that worked for the happy path, it left the activity in a half-broken state if anything between the deletion and `exescorm_parse()` failed: no package on disk, but the DB row still pointed at the (now missing) reference.

In addition, the lack of a `timemodified` update meant downstream code couldn't tell when the package was last refreshed via online save.

## Changes

- `set_ode.php`
  - Replace the wholesale `delete_area_files()` with a targeted delete of the files at `itemid 0` so we only drop the entry that the new file would collide with, keeping the operation reversible if it bails out below.
  - Set `$exescorm->timemodified = time()` together with the new reference so the activity advances in lockstep with the file replacement.
  - Add inline comments documenting the constraint that a SCORM package always lives at `itemid 0` and that `exescorm_parse()` reads from the package filearea using `$exescorm->reference`.

- `tests/online_save_test.php` (new)
  - Integration test simulating two consecutive online saves on the same activity, verifying:
    - the package filearea ends with a single file,
    - that file is the freshly stored one,
    - the activity's `reference` column matches it.
  - Catches regressions where a second online save with a different filename leaves stale files behind in the area.

## Relationship to mod_exescorm#55

The 404 on `content/resources/<uuid>.<ext>` reported in exelearning/exelearning#2094 is fixed on the eXeLearning side by exelearning/exelearning#1740 — the SCORM package is now generated in the browser (where the live Y.Doc and IndexedDB asset blobs are), and `BaseExporter.addAssetsToZipWithResourcePath` also writes each asset under its `<assetId><ext>` literal path so any stale URL still resolves.

This PR does **not** make that symptom go away on its own. It addresses a separate Moodle-side robustness issue: making the package-replacement step idempotent so a partial failure no longer leaves the activity pointing at a missing file, and so the package filearea always ends with exactly one entry matching the activity's `reference`.

Refs: mod_exescorm#55, exelearning/exelearning#1740

## Test plan

- [ ] PHPUnit (`composer test` / docker test target).
- [ ] Manual: create a SCORM activity, edit via eXeLearning Online, save back twice with different package filenames, confirm only the latest one remains in the package filearea and the activity loads correctly.

<!-- moodle-playground-preview:start -->
<hr>
<h3>Moodle Playground Preview</h3>
<p>The changes in this pull request can be previewed and tested using a Moodle Playground instance.</p>

<a href="https://moodle-playground.com?blueprint=eyIkc2NoZW1hIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2F0ZWVkdWNhY2lvbi9tb29kbGUtcGxheWdyb3VuZC9yZWZzL2hlYWRzL21haW4vYXNzZXRzL2JsdWVwcmludHMvYmx1ZXByaW50LXNjaGVtYS5qc29uIiwicHJlZmVycmVkVmVyc2lvbnMiOnsicGhwIjoiOC4zIiwibW9vZGxlIjoiNS4wIn0sImxhbmRpbmdQYWdlIjoiL2NvdXJzZS92aWV3LnBocD9pZD0yIiwiY29uc3RhbnRzIjp7IkFETUlOX1VTRVIiOiJhZG1pbiIsIkFETUlOX1BBU1MiOiJwYXNzd29yZCIsIkFETUlOX0VNQUlMIjoiYWRtaW5AZXhhbXBsZS5jb20ifSwic3RlcHMiOlt7InN0ZXAiOiJpbnN0YWxsTW9vZGxlIiwib3B0aW9ucyI6eyJhZG1pblVzZXIiOiJ7e0FETUlOX1VTRVJ9fSIsImFkbWluUGFzcyI6Int7QURNSU5fUEFTU319IiwiYWRtaW5FbWFpbCI6Int7QURNSU5fRU1BSUx9fSIsInNpdGVOYW1lIjoiZVhlTGVhcm5pbmcgU0NPUk0gRGVtbyIsImxvY2FsZSI6ImVzIiwidGltZXpvbmUiOiJFdXJvcGUvTWFkcmlkIn19LHsic3RlcCI6ImxvZ2luIiwidXNlcm5hbWUiOiJ7e0FETUlOX1VTRVJ9fSJ9LHsic3RlcCI6Imluc3RhbGxNb29kbGVQbHVnaW4iLCJwbHVnaW5UeXBlIjoibW9kIiwicGx1Z2luTmFtZSI6ImV4ZXNjb3JtIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2V4ZWxlYXJuaW5nL21vZF9leGVzY29ybS9hcmNoaXZlL3JlZnMvaGVhZHMvZml4L2lzc3VlLTU1LW9ubGluZS1pbWFnZS1wYXRocy56aXAifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoiZWRpdG9ybW9kZSIsInZhbHVlIjoiZW1iZWRkZWQiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJwcm92aWRlcm5hbWUiLCJ2YWx1ZSI6Ik1vb2RsZSIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6InByb3ZpZGVydmVyc2lvbiIsInZhbHVlIjoiNS4wIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoic2VuZHRlbXBsYXRlIiwidmFsdWUiOiIwIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoibWFuZGF0b3J5ZmlsZXNsaXN0IiwidmFsdWUiOiIvXmNvbnRlbnQodlxcZCspP1xcLnhtbCQvIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoiZm9yYmlkZGVuZmlsZXNsaXN0IiwidmFsdWUiOiIvLipcXC5waHAkLyIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImRpc3BsYXljb3Vyc2VzdHJ1Y3R1cmUiLCJ2YWx1ZSI6IjAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJwb3B1cCIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImZyYW1ld2lkdGgiLCJ2YWx1ZSI6IjEwMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImZyYW1laGVpZ2h0IiwidmFsdWUiOiI1MDAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJ3aW5vcHRncnBfYWR2IiwidmFsdWUiOiIxIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoic2tpcHZpZXciLCJ2YWx1ZSI6IjIiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJoaWRlYnJvd3NlIiwidmFsdWUiOiIwIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoiaGlkZXRvYyIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6Im5hdiIsInZhbHVlIjoiMSIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6Im5hdnBvc2l0aW9ubGVmdCIsInZhbHVlIjoiLTEwMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6Im5hdnBvc2l0aW9udG9wIiwidmFsdWUiOiItMTAwIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoiY29sbGFwc2V0b2N3aW5zaXplIiwidmFsdWUiOiI3NjciLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJkaXNwbGF5YXR0ZW1wdHN0YXR1cyIsInZhbHVlIjoiMSIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImdyYWRlbWV0aG9kIiwidmFsdWUiOiIxIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoibWF4Z3JhZGUiLCJ2YWx1ZSI6IjEwMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6Im1heGF0dGVtcHQiLCJ2YWx1ZSI6IjAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJ3aGF0Z3JhZGUiLCJ2YWx1ZSI6IjAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJmb3JjZWNvbXBsZXRlZCIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImZvcmNlbmV3YXR0ZW1wdCIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImF1dG9jb21taXQiLCJ2YWx1ZSI6IjAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJtYXN0ZXJ5b3ZlcnJpZGUiLCJ2YWx1ZSI6IjEiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJsYXN0YXR0ZW1wdGxvY2siLCJ2YWx1ZSI6IjAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJhdXRvIiwidmFsdWUiOiIwIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoidXBkYXRlZnJlcSIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImV4ZXNjb3Jtc3RhbmRhcmQiLCJ2YWx1ZSI6IjAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJhbGxvd3R5cGVleHRlcm5hbCIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImFsbG93dHlwZWxvY2Fsc3luYyIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImFsbG93dHlwZWV4dGVybmFsYWljYyIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImFsbG93YWljY2hhY3AiLCJ2YWx1ZSI6IjAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJhaWNjaGFjcHRpbWVvdXQiLCJ2YWx1ZSI6IjMwIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoiYWljY2hhY3BrZWVwc2Vzc2lvbmRhdGEiLCJ2YWx1ZSI6IjEiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJhaWNjdXNlcmlkIiwidmFsdWUiOiIxIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoiZm9yY2VqYXZhc2NyaXB0IiwidmFsdWUiOiIxIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoiYWxsb3dhcGlkZWJ1ZyIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImFwaWRlYnVnbWFzayIsInZhbHVlIjoiLioiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJwcm90ZWN0cGFja2FnZWRvd25sb2FkcyIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoiY3JlYXRlQ2F0ZWdvcnkiLCJuYW1lIjoiVGVzdCBDb3Vyc2VzIn0seyJzdGVwIjoiY3JlYXRlQ291cnNlIiwiZnVsbG5hbWUiOiJlWGVMZWFybmluZyBTQ09STSBUZXN0IENvdXJzZSIsInNob3J0bmFtZSI6IkVYRVNDT1JNMDEiLCJjYXRlZ29yeSI6IlRlc3QgQ291cnNlcyIsInN1bW1hcnkiOiJUZXN0IGNvdXJzZSBmb3IgdGhlIGVYZUxlYXJuaW5nIFNDT1JNIHBsdWdpbi4ifSx7InN0ZXAiOiJjcmVhdGVVc2VyIiwidXNlcm5hbWUiOiJzdHVkZW50IiwicGFzc3dvcmQiOiJwYXNzd29yZCIsImVtYWlsIjoic3R1ZGVudEBleGFtcGxlLmNvbSIsImZpcnN0bmFtZSI6IkRlbW8iLCJsYXN0bmFtZSI6IlN0dWRlbnQifSx7InN0ZXAiOiJlbnJvbFVzZXIiLCJ1c2VybmFtZSI6Int7QURNSU5fVVNFUn19IiwiY291cnNlIjoiRVhFU0NPUk0wMSIsInJvbGUiOiJlZGl0aW5ndGVhY2hlciJ9LHsic3RlcCI6ImVucm9sVXNlciIsInVzZXJuYW1lIjoic3R1ZGVudCIsImNvdXJzZSI6IkVYRVNDT1JNMDEiLCJyb2xlIjoic3R1ZGVudCJ9LHsic3RlcCI6ImNyZWF0ZVNlY3Rpb24iLCJjb3Vyc2UiOiJFWEVTQ09STTAxIiwibmFtZSI6IkV4YW1wbGUgU0NPUk0gQWN0aXZpdGllcyJ9LHsic3RlcCI6ImFkZE1vZHVsZSIsIm1vZHVsZSI6ImV4ZXNjb3JtIiwiY291cnNlIjoiRVhFU0NPUk0wMSIsInNlY3Rpb24iOjEsIm5hbWUiOiJUZXN0IENvbnRlbnQiLCJpbnRybyI6IlNhbXBsZSBlWGVMZWFybmluZyBTQ09STSBjb250ZW50IGZvciB0ZXN0aW5nLiIsImV4ZXNjb3JtdHlwZSI6ImxvY2FsIiwicmVmZXJlbmNlIjoidGVzdC1jb250ZW50LmVscHgiLCJkaXNwbGF5IjoxLCJmaWxlcyI6W3siZmlsZWFyZWEiOiJwYWNrYWdlIiwiZmlsZW5hbWUiOiJ0ZXN0LWNvbnRlbnQuZWxweCIsImRhdGEiOnsidXJsIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2V4ZWxlYXJuaW5nL3dwLWV4ZWxlYXJuaW5nL3JlZnMvaGVhZHMvbWFpbi90ZXN0cy9maXh0dXJlcy90ZXN0LWNvbnRlbnQuZWxweCJ9fV19LHsic3RlcCI6ImFkZE1vZHVsZSIsIm1vZHVsZSI6ImV4ZXNjb3JtIiwiY291cnNlIjoiRVhFU0NPUk0wMSIsInNlY3Rpb24iOjEsIm5hbWUiOiJQcm9waWVkYWRlcyIsImludHJvIjoiRXhhbXBsZSBjb250ZW50IGRlbW9uc3RyYXRpbmcgZVhlTGVhcm5pbmcgcHJvcGVydGllcy4iLCJleGVzY29ybXR5cGUiOiJsb2NhbCIsInJlZmVyZW5jZSI6InByb3BpZWRhZGVzLmVscHgiLCJkaXNwbGF5IjoxLCJmaWxlcyI6W3siZmlsZWFyZWEiOiJwYWNrYWdlIiwiZmlsZW5hbWUiOiJwcm9waWVkYWRlcy5lbHB4IiwiZGF0YSI6eyJ1cmwiOiJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vZXhlbGVhcm5pbmcvd3AtZXhlbGVhcm5pbmcvcmVmcy9oZWFkcy9tYWluL3Rlc3RzL2ZpeHR1cmVzL3Byb3BpZWRhZGVzLmVscHgifX1dfSx7InN0ZXAiOiJzZXRMYW5kaW5nUGFnZSIsInBhdGgiOiIvY291cnNlL3ZpZXcucGhwP2lkPTIifV19" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="220" height="51" />
</a>

⚠️ The embedded eXeLearning editor is not included in this preview. You can install it from **Modules > eXeLearning SCORM > Configure** using the "Download & Install Editor" button. All other module features (ELPX upload, viewer, preview) work normally.
<!-- moodle-playground-preview:end -->
