### PR TITLE
Fix optional template setting save without upload

### DIFF
--- a/classes/admin/admin_setting_optional_configstoredfile.php
+++ b/classes/admin/admin_setting_optional_configstoredfile.php
@@ -1,0 +1,113 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Optional variant of Moodle's stored-file admin setting.
+ *
+ * @package    mod_exescorm
+ * @copyright  2025 eXeLearning
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_exescorm\admin;
+
+/**
+ * Optional stored-file admin setting that is safe to leave empty.
+ *
+ * Moodle flags an admin setting as "new" whenever its get_setting() returns
+ * null (see admin_output_new_settings_by_page() in lib/adminlib.php), which
+ * forces the administrator through the "New settings" upgrade page after a
+ * plugin upgrade. The stock admin_setting_configstoredfile keeps returning
+ * null until a file is stored, and its write_setting() rejects the save with
+ * an "errorsetting" message when the filemanager posts no draft item id. For
+ * an optional file (such as the package template) that combination traps the
+ * administrator on the "New settings" page unless they upload a file, even
+ * though no file is required (see issue #2000).
+ *
+ * This subclass keeps the normal stored-file behaviour for real uploads,
+ * replacements and intentional clears, but turns a "nothing submitted /
+ * nothing changed" save into a safe no-op that never deletes an already
+ * stored file and never leaves the configured value as null.
+ */
+class admin_setting_optional_configstoredfile extends \admin_setting_configstoredfile {
+    /** @var bool Whether the last write_setting() was a no-op over a stored file. */
+    private $nofilechange = false;
+
+    /**
+     * Return the stored value, substituting '' for null.
+     *
+     * Returning a non-null value stops admin_output_new_settings_by_page()
+     * from treating an empty optional file as a new/unconfigured setting on
+     * every upgrade. When a file is stored, the real config value (the stored
+     * file path) is returned unchanged so replace/clear detection and the
+     * filemanager rendering keep working as in core.
+     *
+     * @return string The stored file path, or '' when nothing is stored.
+     */
+    public function get_setting() {
+        $value = parent::get_setting();
+        return $value === null ? '' : $value;
+    }
+
+    /**
+     * Persist an uploaded file, or accept an empty submission as a no-op.
+     *
+     * @param mixed $data Draft item id submitted by the filemanager.
+     * @return string Empty string on success, or an error message on failure.
+     */
+    public function write_setting($data) {
+        // No usable draft item id: the filemanager was left untouched or its
+        // draft area was never initialised (issue #2000), or an empty value
+        // ('', null, '0', ...) was posted. Treat it as a successful no-op:
+        // never call file_save_draft_area_files() (it would delete an already
+        // stored file when handed an empty draft) and never return an error.
+        if (!is_number($data) || (int) $data <= 0) {
+            if ($this->get_setting() === '') {
+                // Nothing is stored: record an explicit empty value so the
+                // optional setting is not reported as new on the next upgrade.
+                $this->nofilechange = false;
+                return ($this->config_write($this->name, '') ? '' : get_string('errorsetting', 'admin'));
+            }
+            // A file is already stored: keep it untouched and report no change.
+            $this->nofilechange = true;
+            return '';
+        }
+
+        // A positive draft item id was submitted: defer to Moodle core, which
+        // saves uploaded files, honours an intentionally cleared filemanager
+        // and protects an existing file when the draft area is missing.
+        $this->nofilechange = false;
+        return parent::write_setting($data);
+    }
+
+    /**
+     * Report whether the stored file changed.
+     *
+     * The parent compares stored file hashes to detect a change. Our no-op
+     * branch deliberately skips that bookkeeping, so report "unchanged" here
+     * to avoid a spurious "changes saved" notification when an existing file
+     * was left untouched.
+     *
+     * @param mixed $original Value returned by get_setting() before the write.
+     * @return bool True when the stored file changed.
+     */
+    public function post_write_settings($original) {
+        if ($this->nofilechange) {
+            return false;
+        }
+        return parent::post_write_settings($original);
+    }
+}

--- a/settings.php
+++ b/settings.php
@@ -152,7 +152,7 @@ document.addEventListener("DOMContentLoaded", function() {
         'subdirs' => 0,
     ];
 
-    $settings->add(new admin_setting_configstoredfile('exescorm/template',
+    $settings->add(new \mod_exescorm\admin\admin_setting_optional_configstoredfile('exescorm/template',
         get_string('exescorm:template', 'mod_exescorm'),
         get_string('exescorm:template_desc', 'mod_exescorm'),
         'config', 0, $filemanageroptions

--- a/tests/admin/admin_setting_optional_configstoredfile_test.php
+++ b/tests/admin/admin_setting_optional_configstoredfile_test.php
@@ -1,0 +1,228 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tests for the optional stored-file admin setting.
+ *
+ * @package    mod_exescorm
+ * @copyright  2025 eXeLearning
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_exescorm\admin;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->libdir . '/adminlib.php');
+require_once($CFG->libdir . '/filelib.php');
+
+/**
+ * Regression tests covering the save flow of admin_setting_optional_configstoredfile.
+ *
+ * @covers \mod_exescorm\admin\admin_setting_optional_configstoredfile
+ */
+class admin_setting_optional_configstoredfile_test extends \advanced_testcase {
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+    }
+
+    /**
+     * Build the setting under test with the same options the plugin uses in
+     * its settings page.
+     *
+     * @return admin_setting_optional_configstoredfile
+     */
+    private function build_setting(): admin_setting_optional_configstoredfile {
+        return new admin_setting_optional_configstoredfile(
+            'exescorm/template',
+            'New package template',
+            'Optional package template.',
+            'config',
+            0,
+            [
+                'accepted_types' => ['.zip'],
+                'maxbytes' => 0,
+                'maxfiles' => 1,
+                'subdirs' => 0,
+            ]
+        );
+    }
+
+    /**
+     * Stage a file in a fresh user draft area and return its draft item id.
+     *
+     * @param string $filename Name of the file to stage.
+     * @param string $content Raw file contents.
+     * @return int Draft item id holding the staged file.
+     */
+    private function stage_template_file(string $filename, string $content): int {
+        global $USER;
+        $draftitemid = file_get_unused_draft_itemid();
+        $usercontext = \context_user::instance($USER->id);
+        get_file_storage()->create_file_from_string([
+            'contextid' => $usercontext->id,
+            'component' => 'user',
+            'filearea' => 'draft',
+            'itemid' => $draftitemid,
+            'filepath' => '/',
+            'filename' => $filename,
+        ], $content);
+        return $draftitemid;
+    }
+
+    /**
+     * Return the files stored in the plugin config filearea (excluding dirs).
+     *
+     * @return \stored_file[]
+     */
+    private function get_stored_files(): array {
+        $syscontext = \context_system::instance();
+        return get_file_storage()->get_area_files(
+            $syscontext->id,
+            'exescorm',
+            'config',
+            0,
+            'itemid, filepath, filename',
+            false
+        );
+    }
+
+    /**
+     * A fresh optional setting must report '' instead of null, so Moodle does
+     * not keep flagging it as a new setting on the upgrade page.
+     */
+    public function test_get_setting_returns_empty_string_for_fresh_setting(): void {
+        $setting = $this->build_setting();
+        $this->assertSame('', $setting->get_setting());
+    }
+
+    /**
+     * Saving with no draft item id ('', '0' or null) must succeed without
+     * error, store nothing, and persist an explicit (non-null) empty value.
+     */
+    public function test_write_setting_with_empty_values_returns_empty(): void {
+        $setting = $this->build_setting();
+        $this->assertSame('', $setting->write_setting(''));
+        $this->assertSame('', $setting->write_setting('0'));
+        $this->assertSame('', $setting->write_setting(null));
+        $this->assertCount(0, $this->get_stored_files());
+        // The persisted value must be '' (not null) so the setting is never
+        // treated as new on the upgrade page.
+        $this->assertSame('', get_config('exescorm', 'template'));
+    }
+
+    /**
+     * Saving with a valid but empty draft area (the widget was opened but no
+     * file attached) must still succeed and store nothing.
+     */
+    public function test_write_setting_with_empty_draft_returns_empty(): void {
+        $setting = $this->build_setting();
+        $draftitemid = file_get_unused_draft_itemid();
+        $this->assertSame('', $setting->write_setting((string) $draftitemid));
+        $this->assertCount(0, $this->get_stored_files());
+    }
+
+    /**
+     * Uploading a template must store exactly one file in the plugin config
+     * filearea and expose its path through get_setting().
+     */
+    public function test_write_setting_stores_uploaded_file(): void {
+        $setting = $this->build_setting();
+        $draftitemid = $this->stage_template_file('template.zip', 'dummy package');
+
+        $this->assertSame('', $setting->write_setting((string) $draftitemid));
+
+        $files = $this->get_stored_files();
+        $this->assertCount(1, $files);
+        $file = reset($files);
+        $this->assertSame('template.zip', $file->get_filename());
+        $this->assertSame('/template.zip', $setting->get_setting());
+    }
+
+    /**
+     * Uploading a second file must replace the stored template, leaving
+     * exactly one file in the filearea.
+     */
+    public function test_write_setting_replaces_stored_file(): void {
+        $setting = $this->build_setting();
+        $setting->write_setting((string) $this->stage_template_file('template.zip', 'first'));
+        $this->assertCount(1, $this->get_stored_files());
+
+        $setting->write_setting((string) $this->stage_template_file('template2.zip', 'second'));
+
+        $files = $this->get_stored_files();
+        $this->assertCount(1, $files);
+        $file = reset($files);
+        $this->assertSame('template2.zip', $file->get_filename());
+        $this->assertSame('/template2.zip', $setting->get_setting());
+    }
+
+    /**
+     * Once a template is stored, a later save with no draft (the admin simply
+     * saves the settings page without touching the widget) must keep the file.
+     */
+    public function test_stored_file_is_preserved_on_empty_save(): void {
+        $setting = $this->build_setting();
+        $draftitemid = $this->stage_template_file('template.zip', 'dummy package');
+        $setting->write_setting((string) $draftitemid);
+        $this->assertCount(1, $this->get_stored_files());
+
+        $this->assertSame('', $setting->write_setting(''));
+        $this->assertSame('', $setting->write_setting('0'));
+        $this->assertSame('', $setting->write_setting(null));
+
+        $this->assertCount(1, $this->get_stored_files());
+        $this->assertSame('/template.zip', $setting->get_setting());
+    }
+
+    /**
+     * An empty save that leaves an existing file untouched must not be
+     * reported as a change by post_write_settings().
+     */
+    public function test_empty_save_over_stored_file_reports_no_change(): void {
+        $setting = $this->build_setting();
+        $setting->write_setting((string) $this->stage_template_file('template.zip', 'dummy package'));
+
+        $original = $setting->get_setting();
+        $this->assertSame('', $setting->write_setting(''));
+        $this->assertFalse($setting->post_write_settings($original));
+    }
+
+    /**
+     * Intentionally clearing the filemanager (an existing but empty draft
+     * area) must remove the stored template.
+     */
+    public function test_intentional_clear_removes_stored_file(): void {
+        global $USER;
+        $setting = $this->build_setting();
+        $draftitemid = $this->stage_template_file('template.zip', 'dummy package');
+        $setting->write_setting((string) $draftitemid);
+        $this->assertCount(1, $this->get_stored_files());
+
+        // Simulate the admin opening the filemanager and deleting the file:
+        // a draft area that exists but contains no files.
+        $cleardraftid = file_get_unused_draft_itemid();
+        $usercontext = \context_user::instance($USER->id);
+        get_file_storage()->create_directory($usercontext->id, 'user', 'draft', $cleardraftid, '/');
+
+        $this->assertSame('', $setting->write_setting((string) $cleardraftid));
+        $this->assertCount(0, $this->get_stored_files());
+        $this->assertSame('', $setting->get_setting());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the optional "New package template" admin setting so the settings page can be saved when no template file is uploaded or when the filemanager is left untouched.

## Problem

The template setting uses Moodle's `admin_setting_configstoredfile`. During the plugin upgrade / new-settings flow, Moodle treats the setting as new (`admin_output_new_settings_by_page()` flags any setting whose `get_setting()` is `null`) and the save can fail because `admin_setting_configstoredfile::write_setting()` returns an `errorsetting` when the filemanager posts no/empty `draftitemid` — even though the template is optional.

This blocks admins on the "New settings" page unless they upload a template file (issue exelearning/exelearning#2000).

## Changes

- Add a plugin-local optional stored-file admin setting class `\mod_exescorm\admin\admin_setting_optional_configstoredfile`.
- `get_setting()` reports `''` instead of `null` for an unset optional file, so it is never treated as a new/unconfigured setting.
- `write_setting()` accepts an empty/missing/`'0'`/non-positive draft as a successful no-op: it never calls `file_save_draft_area_files()` with an empty draft (which would delete an existing template) and never returns an error.
- Positive draft item ids are delegated to core, preserving the normal upload / replace / intentional-clear behaviour. File type restrictions (`['.zip']`) are unchanged.
- `post_write_settings()` reports "no change" for an untouched empty save, avoiding a spurious "changes saved" notice.
- Replace the `exescorm/template` setting with the new optional stored-file setting (one line in `settings.php`).
- Add PHPUnit regression tests for empty saves, empty drafts, uploads, replace, preserving existing files, intentional clear, and change detection.

## Testing

- [x] Moodle phpcs (`--standard=moodle`, moodle-cs 3.7.0) — clean on the new files
- [x] PHPUnit `mod/exescorm/tests/admin/admin_setting_optional_configstoredfile_test.php` — 8 tests, 28 assertions, OK (Moodle 5.0.5, PHPUnit 11.5)

Run in a Docker Moodle 5.0.5 environment (`erseco/alpine-moodle`).

<!-- moodle-playground-preview:start -->
<hr>
<h3>Moodle Playground Preview</h3>
<p>The changes in this pull request can be previewed and tested using a Moodle Playground instance.</p>

<a href="https://moodle-playground.com?blueprint=eyIkc2NoZW1hIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2F0ZWVkdWNhY2lvbi9tb29kbGUtcGxheWdyb3VuZC9yZWZzL2hlYWRzL21haW4vYXNzZXRzL2JsdWVwcmludHMvYmx1ZXByaW50LXNjaGVtYS5qc29uIiwicHJlZmVycmVkVmVyc2lvbnMiOnsicGhwIjoiOC4zIiwibW9vZGxlIjoiNS4wIn0sImxhbmRpbmdQYWdlIjoiL2NvdXJzZS92aWV3LnBocD9pZD0yIiwiY29uc3RhbnRzIjp7IkFETUlOX1VTRVIiOiJhZG1pbiIsIkFETUlOX1BBU1MiOiJwYXNzd29yZCIsIkFETUlOX0VNQUlMIjoiYWRtaW5AZXhhbXBsZS5jb20ifSwic3RlcHMiOlt7InN0ZXAiOiJpbnN0YWxsTW9vZGxlIiwib3B0aW9ucyI6eyJhZG1pblVzZXIiOiJ7e0FETUlOX1VTRVJ9fSIsImFkbWluUGFzcyI6Int7QURNSU5fUEFTU319IiwiYWRtaW5FbWFpbCI6Int7QURNSU5fRU1BSUx9fSIsInNpdGVOYW1lIjoiZVhlTGVhcm5pbmcgU0NPUk0gRGVtbyIsImxvY2FsZSI6ImVzIiwidGltZXpvbmUiOiJFdXJvcGUvTWFkcmlkIn19LHsic3RlcCI6ImxvZ2luIiwidXNlcm5hbWUiOiJ7e0FETUlOX1VTRVJ9fSJ9LHsic3RlcCI6Imluc3RhbGxNb29kbGVQbHVnaW4iLCJwbHVnaW5UeXBlIjoibW9kIiwicGx1Z2luTmFtZSI6ImV4ZXNjb3JtIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2V4ZWxlYXJuaW5nL21vZF9leGVzY29ybS9hcmNoaXZlL3JlZnMvaGVhZHMvZml4L29wdGlvbmFsLXRlbXBsYXRlLXNldHRpbmcuemlwIn0seyJzdGVwIjoidW56aXAiLCJjb21tZW50IjoiQXV0by1sb2FkIHRoZSBlWGVMZWFybmluZyBzdGF0aWMgZWRpdG9yIHNvIHRoZSBwbGF5Z3JvdW5kIGJvb3RzIHdpdGggYSB3b3JraW5nIGVkaXRvci4gRmV0Y2hlcyB0aGUgc2hhcmVkIGVkaXRvciByZWxlYXNlIGFzc2V0IG9uY2UgdGhyb3VnaCB0aGUgZ2l0aHViLXByb3h5IChDT1JTKSBhbmQgZXh0cmFjdHMgaXQgaW50byB0aGUgcGx1Z2luJ3MgYnVuZGxlZCBkaXIuIFRoZSBhc3NldCB3cmFwcyBldmVyeXRoaW5nIGluIGEgJ3N0YXRpYy8nIGZvbGRlciwgc28gZXh0cmFjdGluZyBpbnRvICdkaXN0JyB5aWVsZHMgJ2Rpc3Qvc3RhdGljLy4uLicsIHdoaWNoIGVtYmVkZGVkX2VkaXRvcl9zb3VyY2VfcmVzb2x2ZXIgc2VydmVzIHZpYSBpdHMgJ2J1bmRsZWQnIHByZWNlZGVuY2UgKG1vb2RsZWRhdGEgLT4gYnVuZGxlZCAtPiBub25lKS4gUGlubmVkIHRvIG1hdGNoIC5lZGl0b3ItdmVyc2lvbiBmb3IgZGV0ZXJtaW5pc3RpYyBwcmV2aWV3cy4gZW1iZWRkZWRfZWRpdG9yX2luc3RhbGxlciBzdGF5cyBmb3IgcHJvZHVjdGlvbi9vZmZsaW5lIGluc3RhbGxzLiIsImRlc3RpbmF0aW9uIjoiL3d3dy9tb29kbGUvbW9kL2V4ZXNjb3JtL2Rpc3QiLCJkYXRhIjp7InVybCI6Imh0dHBzOi8vZ2l0aHViLXByb3h5LmV4ZWxlYXJuaW5nLmRldi8_cmVwbz1leGVsZWFybmluZy9leGVsZWFybmluZyZyZWxlYXNlPXY0LjAuMSZhc3NldD1leGVsZWFybmluZy1zdGF0aWMtdjQuMC4xLnppcCJ9fSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoiZWRpdG9ybW9kZSIsInZhbHVlIjoiZW1iZWRkZWQiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJwcm92aWRlcm5hbWUiLCJ2YWx1ZSI6Ik1vb2RsZSIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6InByb3ZpZGVydmVyc2lvbiIsInZhbHVlIjoiNS4wIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoic2VuZHRlbXBsYXRlIiwidmFsdWUiOiIwIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoibWFuZGF0b3J5ZmlsZXNsaXN0IiwidmFsdWUiOiIvXmNvbnRlbnQodlxcZCspP1xcLnhtbCQvIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoiZm9yYmlkZGVuZmlsZXNsaXN0IiwidmFsdWUiOiIvLipcXC5waHAkLyIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImRpc3BsYXljb3Vyc2VzdHJ1Y3R1cmUiLCJ2YWx1ZSI6IjAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJwb3B1cCIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImZyYW1ld2lkdGgiLCJ2YWx1ZSI6IjEwMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImZyYW1laGVpZ2h0IiwidmFsdWUiOiI1MDAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJ3aW5vcHRncnBfYWR2IiwidmFsdWUiOiIxIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoic2tpcHZpZXciLCJ2YWx1ZSI6IjIiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJoaWRlYnJvd3NlIiwidmFsdWUiOiIwIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoiaGlkZXRvYyIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6Im5hdiIsInZhbHVlIjoiMSIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6Im5hdnBvc2l0aW9ubGVmdCIsInZhbHVlIjoiLTEwMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6Im5hdnBvc2l0aW9udG9wIiwidmFsdWUiOiItMTAwIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoiY29sbGFwc2V0b2N3aW5zaXplIiwidmFsdWUiOiI3NjciLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJkaXNwbGF5YXR0ZW1wdHN0YXR1cyIsInZhbHVlIjoiMSIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImdyYWRlbWV0aG9kIiwidmFsdWUiOiIxIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoibWF4Z3JhZGUiLCJ2YWx1ZSI6IjEwMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6Im1heGF0dGVtcHQiLCJ2YWx1ZSI6IjAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJ3aGF0Z3JhZGUiLCJ2YWx1ZSI6IjAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJmb3JjZWNvbXBsZXRlZCIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImZvcmNlbmV3YXR0ZW1wdCIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImF1dG9jb21taXQiLCJ2YWx1ZSI6IjAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJtYXN0ZXJ5b3ZlcnJpZGUiLCJ2YWx1ZSI6IjEiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJsYXN0YXR0ZW1wdGxvY2siLCJ2YWx1ZSI6IjAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJhdXRvIiwidmFsdWUiOiIwIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoidXBkYXRlZnJlcSIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImV4ZXNjb3Jtc3RhbmRhcmQiLCJ2YWx1ZSI6IjAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJhbGxvd3R5cGVleHRlcm5hbCIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImFsbG93dHlwZWxvY2Fsc3luYyIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImFsbG93dHlwZWV4dGVybmFsYWljYyIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImFsbG93YWljY2hhY3AiLCJ2YWx1ZSI6IjAiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJhaWNjaGFjcHRpbWVvdXQiLCJ2YWx1ZSI6IjMwIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoiYWljY2hhY3BrZWVwc2Vzc2lvbmRhdGEiLCJ2YWx1ZSI6IjEiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJhaWNjdXNlcmlkIiwidmFsdWUiOiIxIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoiZm9yY2VqYXZhc2NyaXB0IiwidmFsdWUiOiIxIiwicGx1Z2luIjoiZXhlc2Nvcm0ifSx7InN0ZXAiOiJzZXRDb25maWciLCJuYW1lIjoiYWxsb3dhcGlkZWJ1ZyIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoic2V0Q29uZmlnIiwibmFtZSI6ImFwaWRlYnVnbWFzayIsInZhbHVlIjoiLioiLCJwbHVnaW4iOiJleGVzY29ybSJ9LHsic3RlcCI6InNldENvbmZpZyIsIm5hbWUiOiJwcm90ZWN0cGFja2FnZWRvd25sb2FkcyIsInZhbHVlIjoiMCIsInBsdWdpbiI6ImV4ZXNjb3JtIn0seyJzdGVwIjoiY3JlYXRlQ2F0ZWdvcnkiLCJuYW1lIjoiVGVzdCBDb3Vyc2VzIn0seyJzdGVwIjoiY3JlYXRlQ291cnNlIiwiZnVsbG5hbWUiOiJlWGVMZWFybmluZyBTQ09STSBUZXN0IENvdXJzZSIsInNob3J0bmFtZSI6IkVYRVNDT1JNMDEiLCJjYXRlZ29yeSI6IlRlc3QgQ291cnNlcyIsInN1bW1hcnkiOiJUZXN0IGNvdXJzZSBmb3IgdGhlIGVYZUxlYXJuaW5nIFNDT1JNIHBsdWdpbi4ifSx7InN0ZXAiOiJjcmVhdGVVc2VyIiwidXNlcm5hbWUiOiJzdHVkZW50IiwicGFzc3dvcmQiOiJwYXNzd29yZCIsImVtYWlsIjoic3R1ZGVudEBleGFtcGxlLmNvbSIsImZpcnN0bmFtZSI6IkRlbW8iLCJsYXN0bmFtZSI6IlN0dWRlbnQifSx7InN0ZXAiOiJlbnJvbFVzZXIiLCJ1c2VybmFtZSI6Int7QURNSU5fVVNFUn19IiwiY291cnNlIjoiRVhFU0NPUk0wMSIsInJvbGUiOiJlZGl0aW5ndGVhY2hlciJ9LHsic3RlcCI6ImVucm9sVXNlciIsInVzZXJuYW1lIjoic3R1ZGVudCIsImNvdXJzZSI6IkVYRVNDT1JNMDEiLCJyb2xlIjoic3R1ZGVudCJ9LHsic3RlcCI6ImNyZWF0ZVNlY3Rpb24iLCJjb3Vyc2UiOiJFWEVTQ09STTAxIiwibmFtZSI6IkV4YW1wbGUgU0NPUk0gQWN0aXZpdGllcyJ9LHsic3RlcCI6ImFkZE1vZHVsZSIsIm1vZHVsZSI6ImV4ZXNjb3JtIiwiY291cnNlIjoiRVhFU0NPUk0wMSIsInNlY3Rpb24iOjEsIm5hbWUiOiJUZXN0IENvbnRlbnQiLCJpbnRybyI6IlNhbXBsZSBlWGVMZWFybmluZyBTQ09STSBjb250ZW50IGZvciB0ZXN0aW5nLiIsImV4ZXNjb3JtdHlwZSI6ImxvY2FsIiwicmVmZXJlbmNlIjoidGVzdC1jb250ZW50LmVscHgiLCJkaXNwbGF5IjoxLCJmaWxlcyI6W3siZmlsZWFyZWEiOiJwYWNrYWdlIiwiZmlsZW5hbWUiOiJ0ZXN0LWNvbnRlbnQuZWxweCIsImRhdGEiOnsidXJsIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2V4ZWxlYXJuaW5nL3dwLWV4ZWxlYXJuaW5nL3JlZnMvaGVhZHMvbWFpbi90ZXN0cy9maXh0dXJlcy90ZXN0LWNvbnRlbnQuZWxweCJ9fV19LHsic3RlcCI6ImFkZE1vZHVsZSIsIm1vZHVsZSI6ImV4ZXNjb3JtIiwiY291cnNlIjoiRVhFU0NPUk0wMSIsInNlY3Rpb24iOjEsIm5hbWUiOiJQcm9waWVkYWRlcyIsImludHJvIjoiRXhhbXBsZSBjb250ZW50IGRlbW9uc3RyYXRpbmcgZVhlTGVhcm5pbmcgcHJvcGVydGllcy4iLCJleGVzY29ybXR5cGUiOiJsb2NhbCIsInJlZmVyZW5jZSI6InByb3BpZWRhZGVzLmVscHgiLCJkaXNwbGF5IjoxLCJmaWxlcyI6W3siZmlsZWFyZWEiOiJwYWNrYWdlIiwiZmlsZW5hbWUiOiJwcm9waWVkYWRlcy5lbHB4IiwiZGF0YSI6eyJ1cmwiOiJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vZXhlbGVhcm5pbmcvd3AtZXhlbGVhcm5pbmcvcmVmcy9oZWFkcy9tYWluL3Rlc3RzL2ZpeHR1cmVzL3Byb3BpZWRhZGVzLmVscHgifX1dfSx7InN0ZXAiOiJzZXRMYW5kaW5nUGFnZSIsInBhdGgiOiIvY291cnNlL3ZpZXcucGhwP2lkPTIifV19" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="220" height="51" />
</a>

ℹ️ The eXeLearning editor is fetched from the shared release and unpacked into the plugin when the playground boots, so the first load may take a few extra seconds. ELPX upload, viewer and preview work normally.
<!-- moodle-playground-preview:end -->